### PR TITLE
Add API for representation with multiple parts.

### DIFF
--- a/control/dcbf_optimizer.py
+++ b/control/dcbf_optimizer.py
@@ -105,7 +105,7 @@ class NmpcDbcfOptimizer:
 
     def add_convex_to_convex_constraint(self, param, robot_geo, obs_geo, safe_dist):
         mat_A, vec_b = obs_geo.get_convex_rep()
-        robot_G, robot_g = robot_geo.convex_rep()
+        robot_G, robot_g = robot_geo.get_convex_rep()
         # get current value of cbf
         cbf_curr, lamb_curr, mu_curr = get_dist_region_to_region(
             mat_A,
@@ -161,13 +161,14 @@ class NmpcDbcfOptimizer:
         # TODO: wrap params
         # TODO: move safe dist inside attribute `system`
         safe_dist = system._dynamics.safe_dist(system._state._x, 0.1, -1.0, 1.0, param.margin_dist)
+        robot_components = system._geometry.equiv_rep()
         for obs_geo in obstacles_geo:
-            # TODO: need to add case for `add_point_convex_constraint()`
-            if isinstance(system._geometry.rep(), RectangleRegion):
-                self.add_convex_to_convex_constraint(param, system._geometry, obs_geo, safe_dist)
-                # self.add_point_to_convex_constraint(param, obs_geo, safe_dist
-            else:
-                raise NotImplementedError()
+            for robot_comp in robot_components:
+                # TODO: need to add case for `add_point_convex_constraint()`
+                if isinstance(robot_comp, RectangleRegion):
+                    self.add_convex_to_convex_constraint(param, robot_comp, obs_geo, safe_dist)
+                else:
+                    raise NotImplementedError()
 
     def add_warm_start(self, param, system):
         # TODO: wrap params

--- a/models/dubin_car.py
+++ b/models/dubin_car.py
@@ -49,11 +49,8 @@ class DubinCarGeometry:
         self._width = width
         self._region = RectangleRegion(-length / 2, length / 2, -width / 2, width / 2)
 
-    def rep(self):
-        return self._region
-
-    def convex_rep(self):
-        return self._region.get_convex_rep()
+    def equiv_rep(self):
+        return [self._region]
 
     def get_plot_patch(self, state):
         length, width = self._length, self._width

--- a/sim/simulation.py
+++ b/sim/simulation.py
@@ -114,5 +114,5 @@ class SingleAgentSimulation:
             polygon_patch_next = self._robot._system._geometry.get_plot_patch(closedloop_traj[index, :])
             robot_patch.set_xy(polygon_patch_next.get_xy())
 
-        anim = animation.FuncAnimation(fig, update, frames=len(closedloop_traj), interval=100)
-        anim.save("animation/world.gif", dpi=200, writer=animation.writers["ffmpeg"](fps=10))
+        anim = animation.FuncAnimation(fig, update, frames=len(closedloop_traj), interval=1000 * 0.1)
+        anim.save("animation/world.mp4", dpi=300, writer=animation.writers["ffmpeg"](fps=60))


### PR DESCRIPTION
Basically, this change allows us to have multiple-part representation for robot.

I'm considering moving visualization functions and animation functions into test file because we don't have universal visualization API currently. I didn't do it now because I'm thinking this would bring too many conflicts on your working global planners.

Moving them away also allows us not to struggle too much with rotation and translation stuff currently for conference submission. Like this as follow,
https://github.com/HybridRobotics/cbf/blob/6eded7d805106664fc99ff84f1e70ec5fb1f2ef5/control/dcbf_optimizer.py#L124-L140

Let me know how do you think and we can move on for later steps.